### PR TITLE
Feature/authentication chain

### DIFF
--- a/src/main/java/org/graylog/aws/auth/AWSAuthProvider.java
+++ b/src/main/java/org/graylog/aws/auth/AWSAuthProvider.java
@@ -1,0 +1,42 @@
+package org.graylog.aws.auth;
+
+
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import org.graylog.aws.config.AWSPluginConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AWSAuthProvider implements AWSCredentialsProvider {
+    private static final Logger LOG = LoggerFactory.getLogger(AWSAuthProvider.class);
+
+    private AWSCredentialsProvider credentials;
+
+    public AWSAuthProvider(AWSPluginConfiguration config, String accessKey, String secretKey) {
+        if (accessKey != null && secretKey != null
+                && !accessKey.isEmpty() && !secretKey.isEmpty()) {
+            this.credentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey));
+            LOG.debug("Using input specific config");
+        } else if (config.accessKey() != null && config.secretKey() != null
+                && !config.accessKey().isEmpty() && !config.secretKey().isEmpty()) {
+            this.credentials = new AWSStaticCredentialsProvider(new BasicAWSCredentials(config.accessKey(), config.secretKey()));
+            LOG.debug("Using AWS Plugin config");
+        } else {
+            this.credentials = new DefaultAWSCredentialsProviderChain();
+            LOG.debug("Using Default Provider Chain");
+        }
+    }
+
+    @Override
+    public AWSCredentials getCredentials() {
+        return this.credentials.getCredentials();
+    }
+
+    @Override
+    public void refresh() {
+        this.credentials.refresh();
+    }
+}

--- a/src/main/java/org/graylog/aws/inputs/cloudtrail/notifications/CloudtrailSQSClient.java
+++ b/src/main/java/org/graylog/aws/inputs/cloudtrail/notifications/CloudtrailSQSClient.java
@@ -1,15 +1,14 @@
 package org.graylog.aws.inputs.cloudtrail.notifications;
 
-import com.amazonaws.auth.AWSCredentials;
-import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.regions.Region;
 import com.amazonaws.services.sqs.AmazonSQS;
-import com.amazonaws.services.sqs.AmazonSQSClient;
+import com.amazonaws.services.sqs.AmazonSQSClientBuilder;
 import com.amazonaws.services.sqs.model.DeleteMessageRequest;
 import com.amazonaws.services.sqs.model.Message;
 import com.amazonaws.services.sqs.model.ReceiveMessageRequest;
 import com.amazonaws.services.sqs.model.ReceiveMessageResult;
 import com.google.common.collect.Lists;
+import org.graylog.aws.auth.AWSAuthProvider;
 import okhttp3.HttpUrl;
 import org.graylog.aws.config.Proxy;
 import org.slf4j.Logger;
@@ -23,16 +22,14 @@ public class CloudtrailSQSClient {
     private final AmazonSQS sqs;
     private final String queueName;
 
-    public CloudtrailSQSClient(Region region, String queueName, String accessKey, String secretKey, HttpUrl proxyUrl) {
-        final AWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+    public CloudtrailSQSClient(Region region, String queueName, AWSAuthProvider authProvider, HttpUrl proxyUrl) {
+        AmazonSQSClientBuilder clientBuilder = AmazonSQSClientBuilder.standard().withRegion(region.getName()).withCredentials(authProvider);
 
         if(proxyUrl != null) {
-            this.sqs = new AmazonSQSClient(credentials, Proxy.forAWS(proxyUrl));
-        } else {
-            this.sqs = new AmazonSQSClient(credentials);
+            clientBuilder.withClientConfiguration(Proxy.forAWS(proxyUrl));
         }
 
-        this.sqs.setRegion(region);
+        this.sqs = clientBuilder.build();
 
         this.queueName = queueName;
     }

--- a/src/web/components/AWSPluginConfiguration.jsx
+++ b/src/web/components/AWSPluginConfiguration.jsx
@@ -94,7 +94,7 @@ const AWSPluginConfiguration = React.createClass({
                     <dd>{this.state.config.lookup_regions ? this.state.config.lookup_regions : "[not set]" }</dd>
 
                     <dt>Access Key:</dt>
-                    <dd>{this.state.config.access_key ? "***********" : "[not set]" }</dd>
+                    <dd>{this.state.config.access_key ? this.state.config.access_key : "[not set]" }</dd>
 
                     <dt>Secret Key:</dt>
                     <dd>{this.state.config.secret_key ? "***********" : "[not set]"}</dd>


### PR DESCRIPTION
This PR restores the per input AWS authentication (changed in c85cbbe079eef1075e088a20b95efa9046140393 ), it also allows at plugin level auth configuration (the current status) and use of the default authentication chain of AWS SDK.

The Auth resolution chain will go as:
1st - Use current input auth if set
2nd - Use plugin level auth if set
3rd - Delegate to AWS SDK Default Auth Chain (https://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/index.html?com/amazonaws/auth/DefaultAWSCredentialsProviderChain.html) which includes the AssumeRole for EC2 instances

Tried to test it locally, and could test the per input auth, and falling back to default auth chain. But was imposible to me to have the plugin configuration page working to test the plugin level, it is just missing from the configuration page, no section for the AWS plugin. Also did the mvn package and deployed the resultant jar in a working environment and the page is still missing. I Think is some kind of problem with the package system more than the code itself